### PR TITLE
sm7325-common: Rename chargeonly_data_file to chargeonly_vendor_data_…

### DIFF
--- a/sepolicy/vendor/charge_only.te
+++ b/sepolicy/vendor/charge_only.te
@@ -2,9 +2,9 @@ type charge_only, domain;
 type charge_only_exec, exec_type, vendor_file_type, file_type;
 init_daemon_domain(charge_only)
 
-# Read chargeonly_data_file
-allow charge_only chargeonly_data_file:dir rw_dir_perms;
-allow charge_only chargeonly_data_file:file create_file_perms;
+# Read chargeonly_vendor_data_file
+allow charge_only chargeonly_vendor_data_file:dir rw_dir_perms;
+allow charge_only chargeonly_vendor_data_file:file create_file_perms;
 
 # Write to /dev/kmsg
 allow charge_only kmsg_device:chr_file rw_file_perms;

--- a/sepolicy/vendor/file.te
+++ b/sepolicy/vendor/file.te
@@ -2,7 +2,7 @@
 type vendor_persist_camera_file, file_type, vendor_persist_type;
 
 # charge_only_mode
-type chargeonly_data_file, file_type, data_file_type;
+type chargeonly_vendor_data_file, file_type, data_file_type;
 type persist_chargeonly_file, file_type, data_file_type;
 
 # Cutback

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -36,7 +36,7 @@
 /sys/devices/virtual/input/input[0-9]+/xtalk            u:object_r:vendor_sysfs_laser:s0
 
 # Charger
-/data/vendor/chargeonly(/.*)?                           u:object_r:chargeonly_data_file:s0
+/data/vendor/chargeonly(/.*)?                           u:object_r:chargeonly_vendor_data_file:s0
 /(mnt/vendor/persist|persist)/chargeonly(/.*)?          u:object_r:persist_chargeonly_file:s0
 /(vendor|system/vendor)/bin/charge_only_mode            u:object_r:charge_only_exec:s0
 


### PR DESCRIPTION
…file

* For some magical reason, the naming (and not just associations) matter as of a few days ago - no clue why.

Change-Id: I6cf12b455dbf460a9be607d796af3536093e8427 (cherry picked from commit d40cb2d754c2d84fc21e2b58004896d5f40c0c90)